### PR TITLE
node-forge depend v0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@pooltogether/loot-box": "^1.0.0",
     "@graphprotocol/graph-cli": "0.19.0",
     "@graphprotocol/graph-ts": "0.19.0",
-    "mustache": "^4.0.1"
+    "mustache": "^4.0.1", 
+    "node-forge":"^0.10.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION

<img width="1240" alt="Screen Shot 2020-12-14 at 11 53 43 AM" src="https://user-images.githubusercontent.com/36907214/102128991-8741ea00-3e03-11eb-8a20-6f74fd77153c.png">

@asselstine Dealing w this before it gets left behind. 
Or should this be in devDependencies? 